### PR TITLE
Redirect all routes to index.html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Project uses `react-router-dom` to dealing with internal routes, such as `/quiz`, `/result`. 
When we try to access a route defined by react-router-dom, vercel is returning a 404 error, because vercel is trying to find a HTML file with this route.

To fix it, we're creating a vercel.json file to rewrite the default behaviour.